### PR TITLE
[JENKINS-11788] Fix RubyPlugin.from(r) TypeError.

### DIFF
--- a/src/main/java/ruby/RubyPlugin.java
+++ b/src/main/java/ruby/RubyPlugin.java
@@ -155,7 +155,7 @@ public class RubyPlugin extends PluginImpl {
      * Gets the plugin that owns the container.
      */
     public static RubyPlugin from(Ruby r) {
-		IRubyObject v = r.evalScriptlet("Jenkins::Plugin.instance");
+        IRubyObject v = r.evalScriptlet("Jenkins::Plugin.instance.peer");
         if (v==null)        return null;
         return (RubyPlugin) v.toJava(RubyPlugin.class);
     }


### PR DESCRIPTION
This fixes a problem where RubyPlugin was trying to coerce a Jenkins::Plugin
pure-ruby type to a RubyPlugin java type, causing an exception when trying to
enable any ruby plugin for a project.

Regression introduced in c287674f598d611561bf2e9a3bae54ddcc7249c6.
