### PR TITLE
[JENKINS-39414] - Update Stapler JRuby dependency to prevent binary compat issue in Jenkins 2.28+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
       <dependency>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>stapler-jruby</artifactId>
-        <version>1.229</version>
+        <version>1.246</version>
         <exclusions>
           <exclusion>
             <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
Stapler 1.246 introduced new APIs, and unfortunately this APIs do not work correctly with outdated modules of stapler like Stapler JRuby. It caused a blocker regression for updating users (see [JENKINS-39414](https://issues.jenkins-ci.org/browse/JENKINS-39414)).

Fix/hack on the stapler side: https://github.com/stapler/stapler/pull/85

@reviewbybees @jenkinsci/code-reviewers 