### PR TITLE
Plugin facelift + JENKINS-50616 fix for JEP-200

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+#!/usr/bin/env groovy
+buildPlugin(jdkVersions: [8], jenkinsVersions: [null, "2.107.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>ruby-runtime</artifactId>
 	<version>0.10-SNAPSHOT</version>
 	<description>Hosts runtime for enabling pure-Ruby plugins</description>
-	<url>https://wiki.jenkins.io/display/JENKINS/Jenkins+plugin+development+in+Ruby</url>
+	<url>https://wiki.jenkins.io/display/JENKINS/Ruby+Runtime+Plugin</url>
 	<packaging>hpi</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,18 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.447</version>
+		<version>3.7</version>
 	</parent>
 
 	<artifactId>ruby-runtime</artifactId>
 	<version>0.10-SNAPSHOT</version>
   <description>Hosts runtime for enabling pure-Ruby plugins</description>
 	<packaging>hpi</packaging>
+
+  <properties>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
+  </properties>
 
 	<dependencies>
       <dependency>
@@ -31,7 +36,7 @@
     <dependency>
       <groupId>org.jruby.rack</groupId>
       <artifactId>jruby-rack</artifactId>
-      <version>1.0.10</version>
+      <version>1.1.13.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -51,8 +56,7 @@
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.78</version>
-        <configuration>
+        <configuration combine.children="append">
           <maskClasses>org.jruby.</maskClasses>
         </configuration>
       </plugin>
@@ -63,25 +67,18 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
     <repository>
       <id>codehaus</id>
       <url>http://repository.codehaus.org/</url>
-    </repository>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
     </repository>
   </repositories>
 
   <pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,6 @@
             <groupId>org.kohsuke.stapler</groupId>
             <artifactId>stapler-jelly</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>org.jruby.rack</groupId>
-            <artifactId>jruby-rack</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
     <dependency>

--- a/src/main/java/jenkins/ruby/JRubyXStreamClassFilter.java
+++ b/src/main/java/jenkins/ruby/JRubyXStreamClassFilter.java
@@ -10,6 +10,7 @@ import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
+import org.jruby.RubyNil;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
@@ -33,6 +34,7 @@ public class JRubyXStreamClassFilter implements CustomClassFilter {
             RubyBoolean.class.isAssignableFrom(c) ||
             c == RubyFixnum.class ||
             c == RubyHash.class ||
+            c == RubyNil.class ||
             c == RubyObject.class ||
             c == RubyString.class ||
             c == RubySymbol.class ||

--- a/src/main/java/ruby/ModelReloadAction.java
+++ b/src/main/java/ruby/ModelReloadAction.java
@@ -31,7 +31,7 @@ public class ModelReloadAction implements RootAction {
     }
 
     public HttpResponse doIndex() {
-        for (RubyPlugin p : Jenkins.getInstance().getPlugins(RubyPlugin.class)) {
+        for (RubyPlugin p : Jenkins.getActiveInstance().getPlugins(RubyPlugin.class)) {
             p.getExtensions().clear();
             p.callMethod(p.getNativeRubyPlugin(), "load_models");
         }

--- a/src/main/java/ruby/RubyExtensionFinder.java
+++ b/src/main/java/ruby/RubyExtensionFinder.java
@@ -42,7 +42,7 @@ public class RubyExtensionFinder extends ExtensionFinder {
 
     @Override
     public ExtensionComponentSet refresh() throws ExtensionRefreshException {
-        List<RubyPlugin> newList = Jenkins.getInstance().getPlugins(RubyPlugin.class);
+        List<RubyPlugin> newList = Jenkins.getActiveInstance().getPlugins(RubyPlugin.class);
         final List<RubyPlugin> delta = new ArrayList<RubyPlugin>(newList);
         delta.removeAll(parsedPlugins);
         parsedPlugins = newList;

--- a/src/main/java/ruby/RubyPlugin.java
+++ b/src/main/java/ruby/RubyPlugin.java
@@ -156,7 +156,7 @@ public class RubyPlugin extends PluginImpl {
         initRubyLoadPaths();
         initRubyNativePlugin();
 
-        rackContext = new DefaultServletRackContext(new ServletRackConfig(Jenkins.getInstance().servletContext));
+        rackContext = new DefaultServletRackContext(new ServletRackConfig(Jenkins.getActiveInstance().servletContext));
 	}
 
     /**

--- a/src/main/java/ruby/RubyPlugin.java
+++ b/src/main/java/ruby/RubyPlugin.java
@@ -10,6 +10,7 @@ import org.jruby.RubyModule;
 import org.jruby.embed.ScriptingContainer;
 import org.jruby.javasupport.Java;
 import org.jruby.rack.DefaultRackApplication;
+import org.jruby.rack.servlet.DefaultServletRackContext;
 import org.jruby.rack.servlet.ServletRackConfig;
 import org.jruby.rack.servlet.ServletRackContext;
 import org.jruby.rack.servlet.ServletRackEnvironment;
@@ -17,6 +18,7 @@ import org.jruby.rack.servlet.ServletRackResponseEnvironment;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.jelly.jruby.RubyKlassNavigator;
 import org.kohsuke.stapler.lang.Klass;
 
@@ -100,7 +102,7 @@ public class RubyPlugin extends PluginImpl {
 
 	/**
 	 * Registers an extension with this Ruby plugin so that it will be found later on
-	 * <p/>
+	 * <p>
 	 * This method is generally called from inside Ruby, as objects that implement
 	 * extension points register themselves.
 	 *
@@ -154,7 +156,7 @@ public class RubyPlugin extends PluginImpl {
         initRubyLoadPaths();
         initRubyNativePlugin();
 
-        rackContext = new ServletRackContext(new ServletRackConfig(Jenkins.getInstance().servletContext));
+        rackContext = new DefaultServletRackContext(new ServletRackConfig(Jenkins.getInstance().servletContext));
 	}
 
     /**
@@ -291,9 +293,10 @@ public class RubyPlugin extends PluginImpl {
      */
     public void rack(IRubyObject servletHandler) {
         final StaplerRequest req = Stapler.getCurrentRequest();
+        final StaplerResponse resp = Stapler.getCurrentResponse();
         // we don't want the Rack app to consider the portion of the URL that was already consumed
         // to reach to the Rack app, so for PATH_INFO we use getRestOfPath(), not getPathInfo()
-        ServletRackEnvironment env = new ServletRackEnvironment(req, rackContext) {
+        ServletRackEnvironment env = new ServletRackEnvironment(req, resp, rackContext) {
             @Override
             public String getPathInfo() {
                 return req.getRestOfPath();

--- a/src/main/java/ruby/RubyPluginRuntimeResolver.java
+++ b/src/main/java/ruby/RubyPluginRuntimeResolver.java
@@ -21,7 +21,7 @@ class RubyPluginRuntimeResolver extends RubyRuntimeResolver {
 	@Override
 	public Ruby unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
 		String pluginid = reader.getAttribute("pluginid");
-		RubyPlugin plugin = (RubyPlugin) Jenkins.getInstance().getPlugin(pluginid);
+		RubyPlugin plugin = (RubyPlugin) Jenkins.getActiveInstance().getPlugin(pluginid);
 		return plugin.getScriptingContainer().getProvider().getRuntime();
 	}
 

--- a/src/main/java/ruby/RubyPluginRuntimeResolver.java
+++ b/src/main/java/ruby/RubyPluginRuntimeResolver.java
@@ -22,6 +22,11 @@ class RubyPluginRuntimeResolver extends RubyRuntimeResolver {
 	public Ruby unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
 		String pluginid = reader.getAttribute("pluginid");
 		RubyPlugin plugin = (RubyPlugin) Jenkins.getActiveInstance().getPlugin(pluginid);
+		if (plugin == null) {
+			//TODO: JRuby XStream does not document ways to properly propagate such errors.
+			//It just throws runtime exceptions like IllegalArgumentException, so we do it here as well.
+			throw new IllegalStateException("Cannot find Ruby plugin with id=" + pluginid);
+		}
 		return plugin.getScriptingContainer().getProvider().getRuntime();
 	}
 

--- a/src/main/java/ruby/RubyRuntimePlugin.java
+++ b/src/main/java/ruby/RubyRuntimePlugin.java
@@ -31,7 +31,7 @@ public class RubyRuntimePlugin extends Plugin {
     }
 
     private void registerJRubyFacet() {
-        List<Facet> facets = WebApp.get(Jenkins.getInstance().servletContext).facets;
+        List<Facet> facets = WebApp.get(Jenkins.getActiveInstance().servletContext).facets;
         for (Facet f : facets) {
             if (f instanceof JRubyFacet)
                 return; // already there

--- a/src/main/java/ruby/ScriptingContainerHolder.java
+++ b/src/main/java/ruby/ScriptingContainerHolder.java
@@ -37,7 +37,7 @@ public class ScriptingContainerHolder {
     public ScriptingContainerHolder() {
         this.ruby = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
         this.ruby.setCompatVersion(CompatVersion.RUBY1_9);
-        this.ruby.setClassLoader(Jenkins.getInstance().pluginManager.uberClassLoader);
+        this.ruby.setClassLoader(Jenkins.getActiveInstance().pluginManager.uberClassLoader);
     }
 
     private void register(XStream2 xs, ScriptingContainer ruby) {

--- a/src/main/java/ruby/ScriptingContainerHolder.java
+++ b/src/main/java/ruby/ScriptingContainerHolder.java
@@ -30,7 +30,7 @@ public class ScriptingContainerHolder {
      * and then loading up the ruby side of the plugin by creating an
      * instance of the Ruby class Jenkins::Plugin which will serve as
      * its agent in the Ruby world.
-     * <p/>
+     * <p>
      * We also register xstream mappers for JRuby objects so that they
      * can be persisted along with other objects in Jenkins.
      */


### PR DESCRIPTION
I would like to release #5 from @jglick, because we have got an extra regression in the whitelists. Curious fact: Version 0.13 referenced in the [changelog](https://plugins.jenkins.io/ruby-runtime) (2016) has been never actually released. Likely @suryagaddipati experienced some issues with dev environment.  So the release would also include a JRuby dependency bump.

- [x] - Update minimum core requirement to 2.102. We could do a release without this version first, but I doubt it worth the effort
- [x] - Update Parent POM
- [x] - Resolve upper bounds conflict with stapler && fix binary incompatibilities
- [x] - Fix [JENKINS-50616](https://issues.jenkins-ci.org/browse/JENKINS-50616) by adding a RubyNil object to the ClassFilter

@reviewbybees @jglick @suryagaddipati 
